### PR TITLE
Jazz crushing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules
 app.zip
 .vscode/settings.json
 .vscode/settings.json
+moveAppToPi.bat

--- a/src/scripts/app.ts
+++ b/src/scripts/app.ts
@@ -1,4 +1,4 @@
 import { Scheduler } from "./helpers/scheduler";
 
 // Start the bot
-Scheduler.dateRolloverCheck(false);
+Scheduler.dateRolloverCheck(false, true);

--- a/src/scripts/basketballGame.ts
+++ b/src/scripts/basketballGame.ts
@@ -145,6 +145,9 @@ export class BasketballGame {
 
     if (this.isEndOfPeriod || this.isHalftime) {
       let tweetMsg = `${this.statusDetail}\n${this.awayTeamName}-${this.awayTeamScore} ${this.homeTeamName}-${this.homeTeamScore}`;
+      if(this.areTheJazzCrushing()){
+        tweetMsg += " #TheJazzAreCrushing #TakeNote";
+      }
 
       // Only tweet End of 4th if going into overtime / tied game
       if (this.period >= 4 && !this.isTiedGame()) {
@@ -183,6 +186,10 @@ export class BasketballGame {
       let event = this.getGameEventByType(GameEventType.Final, 0);
       let tweetMsg = `${this.statusDetail}\n${this.awayTeamName}-${this.awayTeamScore} ${this.homeTeamName}-${this.homeTeamScore}`;
 
+      if(this.areTheJazzCrushing()){
+        tweetMsg += " #TheJazzHaveCrushed #TakeNote";
+      }
+
       let isGameStatusTextDifferent = event.gameText != this.getGameStatusText();
 
       if (isGameStatusTextDifferent) {
@@ -205,6 +212,33 @@ export class BasketballGame {
 
   private getGameStatusText(): string {
     return `${this.awayTeamName}-${this.awayTeamScore} ${this.homeTeamName}-${this.homeTeamScore} ${this.Event.status.type.detail}`;
+  }
+
+  private areTheJazzCrushing(): boolean {
+    let JazzIsAwayTeam = this.awayTeamName == "Jazz";
+    let JazzIsHomeTeam = this.homeTeamName == "Jazz";
+
+    let isAJazzGame = JazzIsAwayTeam || JazzIsHomeTeam;
+
+
+    if (isAJazzGame) {
+      let JazzScore;
+      let OtherScore;
+
+      if (JazzIsAwayTeam) {
+        JazzScore = this.awayTeamScore;
+        OtherScore = this.homeTeamScore;
+      } else {
+        JazzScore = this.homeTeamScore;
+        OtherScore = this.awayTeamScore;
+      }
+
+      if (JazzScore - OtherScore >= 20) {
+        return true;
+      }
+    }
+
+    return false;
   }
 
   // Recursive-ish via scheduling next run of the same method
@@ -240,7 +274,7 @@ export class BasketballGame {
         // TD maybe find a way to detect inaccurate score  (exploded quarter score or tally up player scores on website)
         if (this.isCompleted || this.isEndOfPeriod || this.isHalftime) {
           let eventType = this.isEndOfPeriod || this.isHalftime ? GameEventType.EndOfPeriod : GameEventType.Final;
-          let periodValue = this.isEndOfPeriod || this.isHalftime ? this.period : 0; // Return 0 for completed games, bc thats what we hardcoded into the event object for those.. //td take that 0 default out 
+          let periodValue = this.isEndOfPeriod || this.isHalftime ? this.period : 0; // Return 0 for completed games, bc thats what we hardcoded into the event object for those.. //td take that 0 default out
           let event = this.getGameEventByType(eventType, periodValue);
 
           //If we havent delayed for this event yet, wait 60seconds before  continuing

--- a/src/scripts/helpers/scheduler.ts
+++ b/src/scripts/helpers/scheduler.ts
@@ -26,13 +26,24 @@ export class Scheduler {
   }
   
   // Recursive-ish via scheduled recalls.  This runs the bot infinitely.
-  public static async dateRolloverCheck(pIsDebug:boolean) {
+  public static async dateRolloverCheck(pIsDebug:boolean, pSkipToday: boolean = false) {
     let currentAPIDate = await ESPN.getAPIDate();
 
     // Schedule all the games for the day and then reschedule tomorrow's api date check
 
     // Date format is YYYY-MM-DD which resolves to Zulu 2021-01-18 00:00. Must be converted into an American timezone by adding timezone offset hours.
     if (this.lastDate != currentAPIDate) {
+
+      if(pSkipToday){
+              let tomorrowDateTime = new Date(currentAPIDate);
+                // Turn Zulu time into MST (GMT-0700) at midnight then add 3 for 3AM then add 24 hours for tomorrow
+                tomorrowDateTime.setHours(tomorrowDateTime.getHours() + 7 + 3 + 24);
+                Scheduler.scheduleThis(() => Scheduler.dateRolloverCheck(pIsDebug), tomorrowDateTime);
+                console.log("Skipping initial day's games. See you tomorrow at " + tomorrowDateTime.toLocaleString() + " for a date rollover check"); 
+
+              return;
+      }
+
       this.scheduleAllAPIGames(pIsDebug).then((numberOfGames) => {
         this.lastDate = currentAPIDate;
         let nextScheduleDate = new Date(currentAPIDate);

--- a/src/scripts/twitter.ts
+++ b/src/scripts/twitter.ts
@@ -62,7 +62,7 @@ export class Twitter {
               console.log();
             }
 
-            reject("shit broke");
+            resolve("shit broke");
           }
 
           if (data) {


### PR DESCRIPTION
Jazz now get extra text when they are crushing (20 point lead)
Ability to skip current day when checking for date rollover (for initial runs when first running the app, in case games have already been tweeted. Will need to change that initial boolean on the fly depending on your situation, may want to add that as an arguement when starting the app or something instead)