### PR TITLE
Adding node types to regular depency

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,11 +10,11 @@
     "node": "^15.0.1",
     "node-schedule": "^1.3.2",
     "oauth": "^0.9.15",
-    "request-promise": "^4.2.6"
+    "request-promise": "^4.2.6",
+    "@types/node": "^14.14.3",
   },
   "devDependencies": {
     "@types/jquery": "^3.5.3",
-    "@types/node": "^14.14.3",
     "@types/oauth": "^0.9.1",
     "rimraf": "^3.0.2",
     "typescript": "^4.2.3"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,10 +1,10 @@
 {
-    "compilerOptions": {
-      "target": "es6",
-      "module": "commonjs",
-      "moduleResolution": "node",
-      "sourceMap": true,
-      "outDir": "dist",
-      "baseUrl": ".",
-    }
+  "compilerOptions": {
+    "target": "es6",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "sourceMap": true,
+    "outDir": "dist",
+    "baseUrl": ".",
   }
+}


### PR DESCRIPTION
build was trying to compile and it didn't have types for the 'requires'